### PR TITLE
Added line in Conventions section...

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ While sniffing traffic, all available options and browsable locations were visit
 From this point forward a few conventions are used to improve readability:
  * `...` indicates that there are multiples of the item the elipses follows or leads, as in lists.
  * Unless stated otherwise, all requests are absolute and directed at: http://www.ows.newegg.com/
+ * As of July 11, 2014 it was found that user-agent string was being checked by server. It must be set to the user-agent string identified by the mobile application. Since this will change it is left to the user to discover the current user-agent string accepted by the server.
 
 ## Table of Contents
  * [Home](home.md)


### PR DESCRIPTION
Newegg have their own reasons for turning-on checking the user-agent.  In order to respect their TOS I didn't want to provide the string that can be seen by using a sniffing proxy like Charles or Fiddler.
